### PR TITLE
Replace non-existent "Longest Arithmetic Sequence" with "Longest Arithmetic Subsequence"

### DIFF
--- a/amazon_1year.csv
+++ b/amazon_1year.csv
@@ -527,7 +527,7 @@ ID,Title,Acceptance,Difficulty,Frequency,Leetcode Question Link
 345,Reverse Vowels of a String,44.2%,Easy,0.031112084201956228, https://leetcode.com/problems/reverse-vowels-of-a-string
 1179,Reformat Department Table,80.6%,Easy,0.030653741091002412, https://leetcode.com/problems/reformat-department-table
 557,Reverse Words in a String III,69.8%,Easy,0.03063547953861342, https://leetcode.com/problems/reverse-words-in-a-string-iii
-1027,Longest Arithmetic Sequence,53.4%,Medium,0.03030534949532895, https://leetcode.com/problems/longest-arithmetic-sequence
+1027,Longest Arithmetic Subsequence,53.4%,Medium,0.03030534949532895, https://leetcode.com/problems/longest-arithmetic-subsequence
 671,Second Minimum Node In a Binary Tree,42.7%,Easy,0.02958795718549609, https://leetcode.com/problems/second-minimum-node-in-a-binary-tree
 452,Minimum Number of Arrows to Burst Balloons,49.6%,Medium,0.029478921626711667, https://leetcode.com/problems/minimum-number-of-arrows-to-burst-balloons
 344,Reverse String,68.5%,Easy,0.029048355159926334, https://leetcode.com/problems/reverse-string

--- a/amazon_2year.csv
+++ b/amazon_2year.csv
@@ -639,7 +639,7 @@ ID,Title,Acceptance,Difficulty,Frequency,Leetcode Question Link
 953,Verifying an Alien Dictionary,54.1%,Easy,0.03117337947619734, https://leetcode.com/problems/verifying-an-alien-dictionary
 814,Binary Tree Pruning,74.5%,Medium,0.03113091859517317, https://leetcode.com/problems/binary-tree-pruning
 1179,Reformat Department Table,80.6%,Easy,0.030653741091002412, https://leetcode.com/problems/reformat-department-table
-1027,Longest Arithmetic Sequence,53.4%,Medium,0.03030534949532895, https://leetcode.com/problems/longest-arithmetic-sequence
+1027,Longest Arithmetic Subsequence,53.4%,Medium,0.03030534949532895, https://leetcode.com/problems/longest-arithmetic-subsequence
 319,Bulb Switcher,45.4%,Medium,0.029852963149681156, https://leetcode.com/problems/bulb-switcher
 501,Find Mode in Binary Search Tree,42.4%,Easy,0.029808466297826082, https://leetcode.com/problems/find-mode-in-binary-search-tree
 191,Number of 1 Bits,49.8%,Easy,0.029560622742018188, https://leetcode.com/problems/number-of-1-bits

--- a/amazon_alltime.csv
+++ b/amazon_alltime.csv
@@ -599,7 +599,7 @@ ID,Title,Acceptance,Difficulty,Frequency,Leetcode Question Link
 1245,Tree Diameter,60.1%,Medium,0.17869178874337593, https://leetcode.com/problems/tree-diameter
 871,Minimum Number of Refueling Stops,31.4%,Hard,0.1769307081590782, https://leetcode.com/problems/minimum-number-of-refueling-stops
 486,Predict the Winner,47.9%,Medium,0.17647417648741714, https://leetcode.com/problems/predict-the-winner
-1027,Longest Arithmetic Sequence,53.4%,Medium,0.17589066646366422, https://leetcode.com/problems/longest-arithmetic-sequence
+1027,Longest Arithmetic Subsequence,53.4%,Medium,0.17589066646366422, https://leetcode.com/problems/longest-arithmetic-subsequence
 977,Squares of a Sorted Array,72.1%,Easy,0.17482111400082578, https://leetcode.com/problems/squares-of-a-sorted-array
 523,Continuous Subarray Sum,24.6%,Medium,0.1741156174236314, https://leetcode.com/problems/continuous-subarray-sum
 670,Maximum Swap,43.6%,Medium,0.1735948056557174, https://leetcode.com/problems/maximum-swap

--- a/facebook_1year.csv
+++ b/facebook_1year.csv
@@ -108,7 +108,7 @@ ID,Title,Acceptance,Difficulty,Frequency,Leetcode Question Link
 378,Kth Smallest Element in a Sorted Matrix,54.3%,Medium,0.5057807371350349, https://leetcode.com/problems/kth-smallest-element-in-a-sorted-matrix
 1094,Car Pooling,56.7%,Medium,0.5042466526679481, https://leetcode.com/problems/car-pooling
 15,3Sum,26.8%,Medium,0.4923847546019265, https://leetcode.com/problems/3sum
-1027,Longest Arithmetic Sequence,53.4%,Medium,0.48432368302048406, https://leetcode.com/problems/longest-arithmetic-sequence
+1027,Longest Arithmetic Subsequence,53.4%,Medium,0.48432368302048406, https://leetcode.com/problems/longest-arithmetic-subsequence
 348,Design Tic-Tac-Toe,54.3%,Medium,0.47793775692115553, https://leetcode.com/problems/design-tic-tac-toe
 140,Word Break II,32.6%,Hard,0.4761853504191846, https://leetcode.com/problems/word-break-ii
 93,Restore IP Addresses,35.6%,Medium,0.47237108409270245, https://leetcode.com/problems/restore-ip-addresses

--- a/facebook_2year.csv
+++ b/facebook_2year.csv
@@ -123,7 +123,7 @@ ID,Title,Acceptance,Difficulty,Frequency,Leetcode Question Link
 224,Basic Calculator,36.8%,Hard,0.8569364892249722, https://leetcode.com/problems/basic-calculator
 494,Target Sum,46.3%,Medium,0.8526861460071543, https://leetcode.com/problems/target-sum
 22,Generate Parentheses,62.7%,Medium,0.8495119409673674, https://leetcode.com/problems/generate-parentheses
-1027,Longest Arithmetic Sequence,53.4%,Medium,0.832909122935104, https://leetcode.com/problems/longest-arithmetic-sequence
+1027,Longest Arithmetic Subsequence,53.4%,Medium,0.832909122935104, https://leetcode.com/problems/longest-arithmetic-subsequence
 1026,Maximum Difference Between Node and Ancestor,66.0%,Medium,0.8326883967450455, https://leetcode.com/problems/maximum-difference-between-node-and-ancestor
 341,Flatten Nested List Iterator,52.9%,Medium,0.8292610077755705, https://leetcode.com/problems/flatten-nested-list-iterator
 1216,Valid Palindrome III,47.8%,Hard,0.8187244879431477, https://leetcode.com/problems/valid-palindrome-iii

--- a/facebook_6months.csv
+++ b/facebook_6months.csv
@@ -252,7 +252,7 @@ ID,Title,Acceptance,Difficulty,Frequency,Leetcode Question Link
 694,Number of Distinct Islands,56.0%,Medium,0.03278982282299087, https://leetcode.com/problems/number-of-distinct-islands
 824,Goat Latin,63.4%,Easy,0.0317991816929387, https://leetcode.com/problems/goat-latin
 44,Wildcard Matching,24.7%,Hard,0.030573033362282363, https://leetcode.com/problems/wildcard-matching
-1027,Longest Arithmetic Sequence,53.4%,Medium,0.03030534949532895, https://leetcode.com/problems/longest-arithmetic-sequence
+1027,Longest Arithmetic Subsequence,53.4%,Medium,0.03030534949532895, https://leetcode.com/problems/longest-arithmetic-subsequence
 191,Number of 1 Bits,49.8%,Easy,0.029560622742018188, https://leetcode.com/problems/number-of-1-bits
 14,Longest Common Prefix,35.4%,Easy,0.029493413243583278, https://leetcode.com/problems/longest-common-prefix
 176,Second Highest Salary,31.6%,Easy,0.029252542837437355, https://leetcode.com/problems/second-highest-salary

--- a/facebook_alltime.csv
+++ b/facebook_alltime.csv
@@ -156,7 +156,7 @@ ID,Title,Acceptance,Difficulty,Frequency,Leetcode Question Link
 346,Moving Average from Data Stream,70.9%,Easy,1.5026900216652235, https://leetcode.com/problems/moving-average-from-data-stream
 1060,Missing Element in Sorted Array,54.5%,Medium,1.492039418216795, https://leetcode.com/problems/missing-element-in-sorted-array
 140,Word Break II,32.6%,Hard,1.4852880807915247, https://leetcode.com/problems/word-break-ii
-1027,Longest Arithmetic Sequence,53.4%,Medium,1.4798547592004279, https://leetcode.com/problems/longest-arithmetic-sequence
+1027,Longest Arithmetic Subsequence,53.4%,Medium,1.4798547592004279, https://leetcode.com/problems/longest-arithmetic-subsequence
 22,Generate Parentheses,62.7%,Medium,1.4598441417994485, https://leetcode.com/problems/generate-parentheses
 128,Longest Consecutive Sequence,45.1%,Hard,1.4545519468166546, https://leetcode.com/problems/longest-consecutive-sequence
 622,Design Circular Queue,43.8%,Medium,1.4518172783301968, https://leetcode.com/problems/design-circular-queue

--- a/google_1year.csv
+++ b/google_1year.csv
@@ -405,7 +405,7 @@ ID,Title,Acceptance,Difficulty,Frequency,Leetcode Question Link
 724,Find Pivot Index,44.0%,Easy,0.03089844155123413, https://leetcode.com/problems/find-pivot-index
 1179,Reformat Department Table,80.6%,Easy,0.030653741091002412, https://leetcode.com/problems/reformat-department-table
 207,Course Schedule,43.1%,Medium,0.030628389490117876, https://leetcode.com/problems/course-schedule
-1027,Longest Arithmetic Sequence,53.4%,Medium,0.03030534949532895, https://leetcode.com/problems/longest-arithmetic-sequence
+1027,Longest Arithmetic Subsequence,53.4%,Medium,0.03030534949532895, https://leetcode.com/problems/longest-arithmetic-subsequence
 1192,Critical Connections in a Network,48.6%,Hard,0.030183377823098576, https://leetcode.com/problems/critical-connections-in-a-network
 240,Search a 2D Matrix II,43.2%,Medium,0.02999287612403949, https://leetcode.com/problems/search-a-2d-matrix-ii
 419,Battleships in a Board,70.0%,Medium,0.02967576814611661, https://leetcode.com/problems/battleships-in-a-board

--- a/google_2year.csv
+++ b/google_2year.csv
@@ -543,7 +543,7 @@ ID,Title,Acceptance,Difficulty,Frequency,Leetcode Question Link
 706,Design HashMap,61.3%,Easy,0.0683442674369718, https://leetcode.com/problems/design-hashmap
 26,Remove Duplicates from Sorted Array,45.1%,Easy,0.06795386974703942, https://leetcode.com/problems/remove-duplicates-from-sorted-array
 504,Base 7,46.2%,Easy,0.06759329113252818, https://leetcode.com/problems/base-7
-1027,Longest Arithmetic Sequence,53.4%,Medium,0.06693948267510934, https://leetcode.com/problems/longest-arithmetic-sequence
+1027,Longest Arithmetic Subsequence,53.4%,Medium,0.06693948267510934, https://leetcode.com/problems/longest-arithmetic-subsequence
 50,Pow(x;n),30.3%,Medium,0.06647190010502257, https://leetcode.com/problems/powx-n
 167,Two Sum II - Input array is sorted,54.1%,Easy,0.06546140041370939, https://leetcode.com/problems/two-sum-ii-input-array-is-sorted
 658,Find K Closest Elements,40.9%,Medium,0.06485254217956125, https://leetcode.com/problems/find-k-closest-elements

--- a/google_alltime.csv
+++ b/google_alltime.csv
@@ -738,7 +738,7 @@ ID,Title,Acceptance,Difficulty,Frequency,Leetcode Question Link
 1300,Sum of Mutated Array Closest to Target,44.2%,Medium,0.07008120825318372, https://leetcode.com/problems/sum-of-mutated-array-closest-to-target
 657,Robot Return to Origin,73.5%,Easy,0.06825676545444917, https://leetcode.com/problems/robot-return-to-origin
 494,Target Sum,46.3%,Medium,0.06721153055721414, https://leetcode.com/problems/target-sum
-1027,Longest Arithmetic Sequence,53.4%,Medium,0.06693948267510934, https://leetcode.com/problems/longest-arithmetic-sequence
+1027,Longest Arithmetic Subsequence,53.4%,Medium,0.06693948267510934,https://leetcode.com/problems/longest-arithmetic-subsequence
 997,Find the Town Judge,50.1%,Easy,0.06548984513511495, https://leetcode.com/problems/find-the-town-judge
 1105,Filling Bookcase Shelves,58.1%,Medium,0.06464285626208545, https://leetcode.com/problems/filling-bookcase-shelves
 485,Max Consecutive Ones,54.6%,Easy,0.06323871592532454, https://leetcode.com/problems/max-consecutive-ones

--- a/microsoft_2year.csv
+++ b/microsoft_2year.csv
@@ -378,7 +378,7 @@ ID,Title,Acceptance,Difficulty,Frequency,Leetcode Question Link
 575,Distribute Candies,61.4%,Easy,0.030890487019338404, https://leetcode.com/problems/distribute-candies
 6,ZigZag Conversion,36.3%,Medium,0.03049597862981453, https://leetcode.com/problems/zigzag-conversion
 316,Remove Duplicate Letters,35.8%,Hard,0.030443751414723153, https://leetcode.com/problems/remove-duplicate-letters
-1027,Longest Arithmetic Sequence,53.4%,Medium,0.03030534949532895, https://leetcode.com/problems/longest-arithmetic-sequence
+1027,Longest Arithmetic Subsequence,53.4%,Medium,0.03030534949532895, https://leetcode.com/problems/longest-arithmetic-subsequence
 994,Rotting Oranges,49.2%,Medium,0.030179582027776965, https://leetcode.com/problems/rotting-oranges
 16,3Sum Closest,46.0%,Medium,0.02976964023166436, https://leetcode.com/problems/3sum-closest
 1197,Minimum Knight Moves,36.1%,Medium,0.02969780239174205, https://leetcode.com/problems/minimum-knight-moves

--- a/microsoft_alltime.csv
+++ b/microsoft_alltime.csv
@@ -424,7 +424,7 @@ ID,Title,Acceptance,Difficulty,Frequency,Leetcode Question Link
 503,Next Greater Element II,56.5%,Medium,0.07339377143296942, https://leetcode.com/problems/next-greater-element-ii
 144,Binary Tree Preorder Traversal,55.7%,Medium,0.0722495403534662, https://leetcode.com/problems/binary-tree-preorder-traversal
 676,Implement Magic Dictionary,54.5%,Medium,0.06995858860691037, https://leetcode.com/problems/implement-magic-dictionary
-1027,Longest Arithmetic Sequence,53.4%,Medium,0.06693948267510934, https://leetcode.com/problems/longest-arithmetic-sequence
+1027,Longest Arithmetic Subsequence,53.4%,Medium,0.06693948267510934, https://leetcode.com/problems/longest-arithmetic-subsequence
 1145,Binary Tree Coloring Game,51.2%,Medium,0.06592172080482424, https://leetcode.com/problems/binary-tree-coloring-game
 1304,Find N Unique Integers Sum up to Zero,76.3%,Easy,0.06210765548004028, https://leetcode.com/problems/find-n-unique-integers-sum-up-to-zero
 350,Intersection of Two Arrays II,51.4%,Easy,0.06202949919751832, https://leetcode.com/problems/intersection-of-two-arrays-ii

--- a/quora_1year.csv
+++ b/quora_1year.csv
@@ -4,7 +4,7 @@ ID,Title,Acceptance,Difficulty,Frequency,Leetcode Question Link
 855,Exam Room,43.1%,Medium,0.22345649138873985, https://leetcode.com/problems/exam-room
 1053,Previous Permutation With One Swap,48.5%,Medium,0.20067069546215116, https://leetcode.com/problems/previous-permutation-with-one-swap
 437,Path Sum III,47.2%,Medium,0.13327677772817573, https://leetcode.com/problems/path-sum-iii
-1027,Longest Arithmetic Sequence,53.4%,Medium,0.11122563511022437, https://leetcode.com/problems/longest-arithmetic-sequence
+1027,Longest Arithmetic Subsequence,53.4%,Medium,0.11122563511022437, https://leetcode.com/problems/longest-arithmetic-subsequence
 780,Reaching Points,29.4%,Hard,0.1040197878075301, https://leetcode.com/problems/reaching-points
 390,Elimination Game,44.5%,Medium,0.0922312242160336, https://leetcode.com/problems/elimination-game
 1329,Sort the Matrix Diagonally,78.4%,Medium,0.08584868273025201, https://leetcode.com/problems/sort-the-matrix-diagonally

--- a/quora_2year.csv
+++ b/quora_2year.csv
@@ -6,7 +6,7 @@ ID,Title,Acceptance,Difficulty,Frequency,Leetcode Question Link
 498,Diagonal Traverse,48.2%,Medium,0.3533581913127385, https://leetcode.com/problems/diagonal-traverse
 437,Path Sum III,47.2%,Medium,0.3499312788602187, https://leetcode.com/problems/path-sum-iii
 1053,Previous Permutation With One Swap,48.5%,Medium,0.20067069546215116, https://leetcode.com/problems/previous-permutation-with-one-swap
-1027,Longest Arithmetic Sequence,53.4%,Medium,0.11122563511022437, https://leetcode.com/problems/longest-arithmetic-sequence
+1027,Longest Arithmetic Subsequence,53.4%,Medium,0.11122563511022437, https://leetcode.com/problems/longest-arithmetic-subsequence
 780,Reaching Points,29.4%,Hard,0.1040197878075301, https://leetcode.com/problems/reaching-points
 390,Elimination Game,44.5%,Medium,0.0922312242160336, https://leetcode.com/problems/elimination-game
 1329,Sort the Matrix Diagonally,78.4%,Medium,0.08584868273025201, https://leetcode.com/problems/sort-the-matrix-diagonally

--- a/quora_alltime.csv
+++ b/quora_alltime.csv
@@ -11,7 +11,7 @@ ID,Title,Acceptance,Difficulty,Frequency,Leetcode Question Link
 1053,Previous Permutation With One Swap,48.5%,Medium,0.20067069546215116, https://leetcode.com/problems/previous-permutation-with-one-swap
 1329,Sort the Matrix Diagonally,78.4%,Medium,0.14787032803970862, https://leetcode.com/problems/sort-the-matrix-diagonally
 162,Find Peak Element,43.3%,Medium,0.14169934441669452, https://leetcode.com/problems/find-peak-element
-1027,Longest Arithmetic Sequence,53.4%,Medium,0.11122563511022437, https://leetcode.com/problems/longest-arithmetic-sequence
+1027,Longest Arithmetic Subsequence,53.4%,Medium,0.11122563511022437, https://leetcode.com/problems/longest-arithmetic-subsequence
 31,Next Permutation,32.6%,Medium,0.11042119699719148, https://leetcode.com/problems/next-permutation
 380,Insert Delete GetRandom O(1),47.5%,Medium,0.1088270483839184, https://leetcode.com/problems/insert-delete-getrandom-o1
 452,Minimum Number of Arrows to Burst Balloons,49.6%,Medium,0.10828689439229534, https://leetcode.com/problems/minimum-number-of-arrows-to-burst-balloons

--- a/snapdeal_alltime.csv
+++ b/snapdeal_alltime.csv
@@ -1,2 +1,2 @@
 ID,Title,Acceptance,Difficulty,Frequency,Leetcode Question Link
-1027,Longest Arithmetic Sequence,53.4%,Medium,0, https://leetcode.com/problems/longest-arithmetic-sequence
+1027,Longest Arithmetic Subsequence,53.4%,Medium,0, https://leetcode.com/problems/longest-arithmetic-subsequence


### PR DESCRIPTION
I think a mistake was made here and wrote “Sequence” instead of “Subsequence”.

Proof that it is spelled “Subsequence”: [Longest Arithmetic Subsequence](https://leetcode.com/problems/longest-arithmetic-subsequence/description/)